### PR TITLE
Lssttd 472

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 *.svg
 *.cut*
 test_fakelims.db
+build
+

--- a/python/lcatr/harness/remote.py
+++ b/python/lcatr/harness/remote.py
@@ -66,4 +66,14 @@ def rsync(src,dst):
     cmdstr = "rsync -a %s %s" % (src, dst)
     return command(cmdstr)
 
+def mkdir(target_dir, host, user):
+    '''
+    Execute mkdir on a remote <user>@<host> connection
+    '''
+    cmdstr = 'mkdir -p %s' % target_dir
+    return cmd(cmdstr, host, user)
+
+def scp(src, dst):
+    cmdstr = "scp -p %s %s" % (src, dst)
+    return command(cmdstr)
 

--- a/python/lcatr/harness/remote_irods.py
+++ b/python/lcatr/harness/remote_irods.py
@@ -1,0 +1,38 @@
+from remote import *
+
+def cmd(cmdstr, retries=1):
+    '''
+    Run cmd on localhost, supposed to be set up for IRODS access.
+
+    Return triple of (status, stdout, stderr).
+    '''
+    if isinstance(cmdstr,list): cmdstr = ' '.join(cmdstr)
+    return command(cmdstr, retries)
+
+def stat(path, host = "localhost", user = os.environ.get('USER')):
+    '''
+    Return output of the "stat" command run as user@host.
+
+    See cmd() for return values. 
+    '''
+    return cmd("ils %s" % path)
+
+def rsync(src,dst):
+    '''
+    Copy a remote file/dir "src" to a destination "dst".
+    '''
+    cmdstr = "irsync -ra %s %s" % (src, dst)
+    return cmd(cmdstr)
+
+def mkdir(target_dir, host, user):
+    '''
+    Execute mkdir on a remote <user>@<host> connection
+    '''
+    cmdstr = 'imkdir -p %s' % target_dir
+    return cmd(cmdstr)
+
+def scp(src, dst):
+    cmdstr = "icp -p %s %s" % (src, dst)
+    return cmd(cmdstr)
+
+


### PR DESCRIPTION
on irods side this branch seems ok for my preliminary checks : using fake_lims and checking that it does correctly send the summary.lims in irods. I believe that the next stage (reenabling filerefs in validator_aspic_testing.py) will be independent from the modifs here.
